### PR TITLE
Update JvmCheck.java

### DIFF
--- a/releng/plugin_jvmcheck/src/lang_project_id/jvmcheck/JvmCheck.java
+++ b/releng/plugin_jvmcheck/src/lang_project_id/jvmcheck/JvmCheck.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/** *****************************************************************************
  * Copyright (c) 2015, 2015 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,7 +7,7 @@
  *
  * Contributors:
  *     Bruno Medeiros - initial API and implementation
- *******************************************************************************/
+ ****************************************************************************** */
 package lang_project_id.jvmcheck;
 
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -18,68 +18,78 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
 public class JvmCheck implements IStartup, JvmCheckConstants_Actual {
-	
-	public static String getJavaVersionProperty() {
-		return System.getProperty("java.version");
-	}
-	
-	public static int getJavaVersion() {
-	    String versionProperty = getJavaVersionProperty();
-	    String[] versionSegments = versionProperty.split("\\.");
-	    
-	    if(versionSegments.length < 2) {
-	    	return -1;
-	    }
-	    String javaVersionStr = versionSegments[1];
-		
-	    try {
-			return Integer.parseInt(javaVersionStr);
-		} catch(NumberFormatException e) {
-			return -1;
-		}
-	}
-	
-	@Override
-	public void earlyStartup() {
-		final int javaVersion = getJavaVersion();
-		
-		if(javaVersion >= REQUIRED_JAVA_VERSION)
-			return;
-		
-		// Show error message to the user, because the platform just silently fails. 
-		// See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=417336
-		
-		Display.getDefault().asyncExec(new Runnable() {
-			@Override
-			public void run() {
-				Shell activeShell = getActiveWorkbenchShell();
-				
-				String message = "Could not start " + FEATURE_NAME + " because Java version is: " + javaVersion 
-						+ "\nVersion " + REQUIRED_JAVA_VERSION + " is required";
-				
-				System.err.println(message);
-				
-				if(activeShell == null) {
-					return;
-				}
-				MessageDialog.openError(activeShell, "Error", message);
-			}
-		});
-	
-	}
-	
-	/** Gets the active workbench window. */
-	public static IWorkbenchWindow getActiveWorkbenchWindow() {
-		return PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-	}
-	
-	/** Gets the active workbench shell. */
-	public static Shell getActiveWorkbenchShell() {
-		IWorkbenchWindow window = getActiveWorkbenchWindow();
-		if(window != null) {
-			return window.getShell();
-		}
-		return null;
-	}
-	
+
+    public static String getJavaVersionProperty() {
+        return System.getProperty("java.version");
+    }
+
+    public static int getJavaVersion() {
+        String versionProperty = getJavaVersionProperty();
+        String[] versionSegments = versionProperty.split("\\.");
+
+        if (versionSegments.length < 2) {
+            return -1;
+        }
+        String javaVersionStr;
+        if ("1".equals(versionSegments[0])) {
+            // For old versions is like 1.9 
+            javaVersionStr = versionSegments[1];
+        } else {
+            // For newer versions is like 15.0
+            javaVersionStr = versionSegments[0];
+        }
+
+        try {
+            return Integer.parseInt(javaVersionStr);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    @Override
+    public void earlyStartup() {
+        final int javaVersion = getJavaVersion();
+
+        if (javaVersion >= REQUIRED_JAVA_VERSION) {
+            return;
+        }
+
+        // Show error message to the user, because the platform just silently fails. 
+        // See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=417336
+        Display.getDefault().asyncExec(new Runnable() {
+            @Override
+            public void run() {
+                Shell activeShell = getActiveWorkbenchShell();
+
+                String message = "Could not start " + FEATURE_NAME + " because Java version is: " + javaVersion
+                        + "\nVersion " + REQUIRED_JAVA_VERSION + " is required";
+
+                System.err.println(message);
+
+                if (activeShell == null) {
+                    return;
+                }
+                MessageDialog.openError(activeShell, "Error", message);
+            }
+        });
+
+    }
+
+    /**
+     * Gets the active workbench window.
+     */
+    public static IWorkbenchWindow getActiveWorkbenchWindow() {
+        return PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+    }
+
+    /**
+     * Gets the active workbench shell.
+     */
+    public static Shell getActiveWorkbenchShell() {
+        IWorkbenchWindow window = getActiveWorkbenchWindow();
+        if (window != null) {
+            return window.getShell();
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
This fixes error when DDT startup with message: "Could not start DDT because java version is 0 Version 8 is required."
Wrong java version parsing: relying on 1.x format - when newer format is 15.0 etc.

Error was posted: here: https://forum.dlang.org/thread/eorrsqrentdqoyjimede@forum.dlang.org